### PR TITLE
feat(cli): command aliases

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,9 @@ pub enum Format {
 #[derive(Subcommand)]
 pub enum ProfileCommands {
     /// Lists available profiles
+    #[clap(aliases = &["l", "li"])]
     List,
+    #[clap(aliases = &["a"])]
     Add {
         /// enables add in interactive mode
         #[arg(short, default_value_t = false)]
@@ -25,12 +27,16 @@ pub enum ProfileCommands {
         cfg: String,
     },
     /// Prints current profile
+    #[clap(aliases = &["g"])]
     Get,
     /// Sets current profile
+    #[clap(aliases = &["s"])]
     Set { name: String },
     /// Sets current profile
+    #[clap(aliases = &["r", "rm"])]
     Remove { name: String },
     /// Dumps current profile configuration
+    #[clap(aliases = &["d"])]
     Dump {
         /// output format
         #[arg(short, long, value_enum, default_value_t = Format::Json)]
@@ -41,22 +47,21 @@ pub enum ProfileCommands {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Access to available profiles
+    #[clap(aliases = &["p", "pr", "prof"])]
     Profile {
         #[command(subcommand)]
         command: ProfileCommands,
     },
+    #[clap(aliases = &["l", "li"])]
     List {
         path: String,
         #[arg(short, long)]
         paginate: Option<usize>,
     },
-    Delete {
-        path: String,
-    },
-    Upload {
-        src: String,
-        dest: String,
-    },
+    #[clap(aliases = &["d", "del"])]
+    Delete { path: String },
+    #[clap(aliases = &["u", "up"])]
+    Upload { src: String, dest: String },
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
added short aliases for CLI commands such as `list` -> [`l`, `li`]
