### PR TITLE
fix(cli): disable configuration file truncation to avoid erasing it

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -31,7 +31,7 @@ where
         .read(true)
         .write(true)
         .create(true)
-        .truncate(true)
+        .truncate(false)
         .open(path)
         .await?;
 
@@ -209,7 +209,6 @@ mod tests {
         }
     }
 
-    #[ignore]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn should_load_a_valid_configuration() {
         let dir = TmpDir::create_tmp_dir();
@@ -229,7 +228,6 @@ mod tests {
         assert!(cfg.contains_key("gcs"));
     }
 
-    #[ignore]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn should_persist_new_configuration() {
         let dir = TmpDir::create_tmp_dir();


### PR DESCRIPTION
In this PR it is changed how the configuration file is opened. In particular, it is not truncated anymore, so that the connection profiles previously configured are not erased anymore upon launching the cli.

In addition, ignored tests are reinstated as they are passing due to the provided fix.