### PR TITLE
feat(cli): introduce basic download command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,8 @@ pub enum Commands {
     Delete { path: String },
     #[clap(aliases = &["u", "up"])]
     Upload { src: String, dest: String },
+    #[clap(aliases = &["d", "down"])]
+    Download { src: String, dest: String },
 }
 
 #[derive(Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub enum Commands {
     Delete { path: String },
     #[clap(aliases = &["u", "up"])]
     Upload { src: String, dest: String },
-    #[clap(aliases = &["d", "down"])]
+    #[clap(aliases = &["dw", "down"])]
     Download { src: String, dest: String },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,23 @@ async fn run() -> Result<(), CliError> {
 
             client.upload(&src, &dest, None).await?;
         }
+        Commands::Download { src, dest } => {
+            welcome();
+
+            let profile = get_profile(args.profile, pers, cfg)?;
+
+            ok(format!(
+                "downloading file '{}' to '{}' for profile '{}'\n",
+                src,
+                dest.as_str().bold().green(),
+                profile.bold().cyan()
+            ));
+
+            let client = create_client(&profile, cfg)?.unwrap();
+
+            let contents = client.download(&src).await?;
+            fs::write(dest, contents).await.unwrap();
+        }
     };
 
     Ok(())


### PR DESCRIPTION
Hi! This PR introduce a basic download command to the cli.  
This command can be employed to download a single file from selected bucket and store it in the provided file path.